### PR TITLE
feat: add tree-sitter-kotlin as main AST by interop

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,28 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+    - name: Pre Build tree sitter
+      run: cd vendor/tree-sitter-kotlin && npm install && npx tree-sitter generate && cd ../..
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with: 
+        submodules: recursive
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,11 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
-      with: 
+      with:
         submodules: recursive
     - name: Use Node.js
       uses: actions/setup-node@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,12 +20,12 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20.x'
-    - name: Go to tree sitter
-      run: cd vendor/tree-sitter-kotlin
     - name: Build tree sitter
-      run: npm install && npx tree-sitter generate
-    - name: Leave tree sitter
-      run: cd ../.. && ls
+      working-directory: vendor/tree-sitter-kotlin
+      run: |
+          cd vendor/tree-sitter-kotlin
+          npm install
+          npx tree-sitter generate
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,8 +20,12 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20.x'
-    - name: Pre Build tree sitter
-      run: ls vendor/tree-sitter-kotlin && cd vendor/tree-sitter-kotlin && npm install && npx tree-sitter generate && cd ../..
+    - name: Go to tree sitter
+      run: cd vendor/tree-sitter-kotlin
+    - name: Build tree sitter
+      run: npm install && npx tree-sitter generate
+    - name: Leave tree sitter
+      run: cd ../.. && ls
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,24 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Pre Build tree sitter
+      run: cd vendor/tree-sitter-kotlin && npm install && npx tree-sitter generate && cd ../..
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         node-version: '20.x'
     - name: Pre Build tree sitter
-      run: ls && cd vendor/tree-sitter-kotlin && npm install && npx tree-sitter generate && cd ../..
+      run: ls vendor/tree-sitter-kotlin && cd vendor/tree-sitter-kotlin && npm install && npx tree-sitter generate && cd ../..
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,6 @@ jobs:
     - name: Build tree sitter
       working-directory: vendor/tree-sitter-kotlin
       run: |
-          cd vendor/tree-sitter-kotlin
           npm install
           npx tree-sitter generate
     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         node-version: '20.x'
     - name: Pre Build tree sitter
-      run: cd vendor/tree-sitter-kotlin && npm install && npx tree-sitter generate && cd ../..
+      run: ls && cd vendor/tree-sitter-kotlin && npm install && npx tree-sitter generate && cd ../..
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/tree-sitter-kotlin"]
+	path = vendor/tree-sitter-kotlin
+	url = https://github.com/EllianCarlos/tree-sitter-kotlin.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cc"
+version = "1.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,10 +139,13 @@ dependencies = [
 name = "etanol"
 version = "0.0.0"
 dependencies = [
+ "cc",
  "env",
  "regex",
  "tokio",
  "tower-lsp",
+ "tree-sitter",
+ "tree-sitter-highlight",
 ]
 
 [[package]]
@@ -649,6 +661,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +722,26 @@ name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -851,6 +889,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+dependencies = [
+ "cc",
+ "regex",
+]
+
+[[package]]
+name = "tree-sitter-highlight"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "042342584c5a7a0b833d9fc4e2bdab3f9868ddc6c4b339a1e01451c6720868bc"
+dependencies = [
+ "regex",
+ "thiserror",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,16 @@
 name = "etanol"
 version = "0.0.0"
 edition = "2021"
+build = "build.rs"
 
 [dependencies]
 env = "1.0.1"
 regex = "1.11.1"
 tokio = { version = "1", features = ["full"]}
 tower-lsp = "0.20.0"
+tree-sitter = "0.20"
+tree-sitter-highlight = "0.20"
+
+[build-dependencies]
+cc = "1.0"
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ devenv shell
 
 and you have a shell with everything ready to go. If you use macos or windows, help setting those environments is welcome! 
 
+## Other modules
+
+This projects uses interoperability between rust and c to use the [tree-sitter-kolint](https://github.com/EllianCarlos/tree-sitter-kotlin.git). For that setup correctly the modules in `.gitmodules`.
+
 You're also gonna need to port the `tree-sitter-kotlin` to `c` to enable interop with Rust. For this do:
 ```sh 
 cd vendor/tree-sitter-kotlin
@@ -18,14 +22,12 @@ npx tree-sitter generate
 cd ../..
 ```
 
-Or just:
+Or with devenv just:
 ```sh
 cd vendor/tree-sitter-kotlin
 tree-sitter generate
 cd ../..
 ```
-
-In NixOS (or an OS supporting devenv).
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,23 @@ devenv shell
 
 and you have a shell with everything ready to go. If you use macos or windows, help setting those environments is welcome! 
 
+You're also gonna need to port the `tree-sitter-kotlin` to `c` to enable interop with Rust. For this do:
+```sh 
+cd vendor/tree-sitter-kotlin
+npm install
+npx tree-sitter generate
+cd ../..
+```
+
+Or just:
+```sh
+cd vendor/tree-sitter-kotlin
+tree-sitter generate
+cd ../..
+```
+
+In NixOS (or an OS supporting devenv).
+
 ## Testing
 
 After entering a devenv shell, open the client folder in vscode, press `F5`, this will open another vscode windows now running in the extension developer mode. After that you should be able to be using the LSP.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+extern crate cc;
+
+fn main() {
+    cc::Build::new()
+        .include("vendor/tree-sitter-kotlin/src")
+        .file("vendor/tree-sitter-kotlin/src/parser.c")
+        .file("vendor/tree-sitter-kotlin/src/scanner.c")
+        .compile("tree-sitter-kotlin");
+}

--- a/dev-testing/main.kt
+++ b/dev-testing/main.kt
@@ -1,4 +1,4 @@
 fun main() {
-    println("Hello, Kotlin!");
-    return;
+    println("Hello, Kotlin!")
+    return
 }

--- a/dev-testing/main.kt
+++ b/dev-testing/main.kt
@@ -1,4 +1,4 @@
 fun main() {
-    println("Hello, Kotlin!")
-    return
+    println("Hello, Kotlin!");
+    return;
 }

--- a/devenv.nix
+++ b/devenv.nix
@@ -9,6 +9,7 @@
     pkgs.git
     pkgs.vscode
     pkgs.kotlin
+    pkgs.tree-sitter
   ];
 
   # https://devenv.sh/languages/

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -1,3 +1,4 @@
 # Architectural (?) Decision Record
 
 - [2025-03-24] Using `kotlinc` process instead of a in memory parser to speed up development.
+- [2025-04-14] Using interop with tree-sitter instead of implementing an AST parser for kotlin.

--- a/src/interop/mod.rs
+++ b/src/interop/mod.rs
@@ -1,0 +1,1 @@
+pub mod tree_sitter;

--- a/src/interop/tree_sitter.rs
+++ b/src/interop/tree_sitter.rs
@@ -1,0 +1,9 @@
+use tree_sitter::{Parser, Language};
+
+extern "C" { fn tree_sitter_kotlin() -> Language; }
+
+pub fn get_parser() -> Parser {
+    let mut parser = Parser::new();
+    parser.set_language( unsafe { tree_sitter_kotlin() }).expect("Error loading Kotlin grammar.");
+    parser
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod server;
 mod handlers;
 mod syntax;
 mod util;
+mod interop;
 
 use crate::server::KotlinLsp;
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -5,6 +5,7 @@ use regex::Regex;
 
 use crate::server::KotlinLsp;
 use crate::util::create_temp_file;
+use crate::interop::tree_sitter::get_parser;
 
 pub async fn check_syntax(lsp: &KotlinLsp, code: &str, uri: &str) {
     let temp_file = create_temp_file(lsp, code).await;
@@ -60,4 +61,10 @@ pub async fn check_syntax(lsp: &KotlinLsp, code: &str, uri: &str) {
 
         lsp.client.publish_diagnostics(Url::parse(uri).unwrap(), diagnostics, None).await;
     }
+    let mut parser = get_parser();
+    let tree = parser.parse(&code, None).expect("Failed to parse");
+    let root_node_kind = tree.root_node().kind().to_string();
+    lsp.client
+        .log_message(MessageType::INFO, format!("Root node type: {}", root_node_kind))
+        .await;
 }


### PR DESCRIPTION
Add tree-sitter-kotlin support to the project by Rust interop to enable more features in the LSP.

# Tests
No tests in this project yet.

# Module changes
Added a new module, called interop.

